### PR TITLE
Adding basic age gating for mature wikis.

### DIFF
--- a/_data/history.yml
+++ b/_data/history.yml
@@ -1,6 +1,6 @@
 - event:
   date: "October 21, 2022"
-  description: "The GWN is relaunched with 11 founding members and 3 affiliates. The founding members are the JiggyWikki, Conker Wiki, Rare Wiki, Triforce Wiki, Crash Bandicoot Wiki, Spyro Wiki, Final Fantasy Wiki, Wiki of Mana, Speedrunwiki.com, SaGa Wiki, and MediEvil Wiki (now Gallowpedia). It is affiliated with the Arthur Wiki, Diary of a Wimpy Kid Wiki, and SpongeBob Wiki. A new logo is made and the wiki footer is updated."
+  description: "The GWN is relaunched with 11 founding members and 3 affiliates. The founding members are the JiggyWikki, Conker Wiki, Rare Wiki, Triforce Wiki, Crash Bandicoot Wiki, Spyro Wiki, Final Fantasy Wiki, Wiki of Mana, Speedrunwiki.com, SaGa Wiki, and MediEvil Wiki (now Gallowpedia). It is affiliated with the Arthur Wiki, the (now defunct) Diary of a Wimpy Kid Wiki, and SpongeBob Wiki. A new logo is made and the wiki footer is updated."
 - event:
   date: "November 21, 2022"
   description: "SEIWA becomes an affiliate of the GWN."

--- a/_data/members.yml
+++ b/_data/members.yml
@@ -3,9 +3,10 @@
   name: "Conker Wiki"
   description: "Conker Wiki is a wiki covering the Conker series of games. Since April 2019, Conker Wiki has been hosted by Grifkuba."
   logo: "/images/logos/conker.png"
-  url: "https://conkerwiki.com/"
+  url: "https://gamingwikinetwork.org/warn/conkerwiki"
   mainpage: "Main_Page"
   discord: "s7fyT4E"
+  age: 17+
 - member:
   id: "crashbandicootwiki"
   name: "Crash Bandicoot Wiki"
@@ -26,7 +27,7 @@
   name: "Dune: Awakening Community Wiki"
   description: "The Dune: Awakening Community Wiki is the community knowledge base for everything to do with Funcom's latest and boldest MMO Survival game, set on the sands of Arrakis in Frank Herbert's DUNE, in collaboration with from the publishers of Denis Villeneuve's latest movies, Legendary."
   logo: "/images/logos/duneawakeningcommunitywiki.png"
-  url: "https://awakening.wiki/"
+  url: "https://gamingwikinetwork.org/warn/dacw"
   mainpage: ""
   discord: "K6xgpKqMTj"
   age: 18+
@@ -35,7 +36,7 @@
   name: "Independent Fallout Wiki"
   description: "The Independent Fallout Wiki is a fan-owned project focused on maintaining the most comprehensive, user-friendly encyclopedia about all aspects of the Fallout franchise, including the games, television series, community, and mods!"
   logo: "/images/logos/fallout.png"
-  url: "https://fallout.wiki/"
+  url: "https://gamingwikinetwork.org/warn/falloutwiki"
   mainpage: "Fallout_Wiki"
   discord: "falloutwiki"
   twitter: "thefalloutwiki"
@@ -57,7 +58,7 @@
   name: "Harvester Wiki"
   description: "Harvester Wiki is the largest, most comprehensive source of Harvester information!"
   logo: "/images/logos/HarvesterWiki.png"
-  url: "https://harvester.telepedia.net/"
+  url: "https://gamingwikinetwork.org/warn/harvesterwiki"
   mainpage: "Harvester_Wiki"
   age: 18+
 - member:
@@ -92,7 +93,7 @@
   name: "Final Fantasy Wiki"
   description: "Final Fantasy Wiki is an independent wiki covering Final Fantasy and related franchises. It was founded in January 2020 by members of the Square Enix Independent Wiki Alliance, as they did not have a representative wiki for Final Fantasy, the flagship franchise of Square Enix. The wiki utilizes a format that is derived from both the Kingdom Hearts Wiki and the Super Mario Wiki."
   logo: "/images/logos/finalfantasy.png"
-  url: "https://finalfantasywiki.com/"
+  url: "https://gamingwikinetwork.org/warn/finalfantasywiki"
   mainpage: "Main_Page"
   discord: "PBDCHYq"
   twitter: "theFFWiki"
@@ -102,25 +103,28 @@
   name: "Mamiya Wiki"
   description: "Mamiya Wiki is a very small fan-hosted wiki for the visual novel Mamiya: A Shared Illusion of the World's End. The wiki, in its current form, was founded on April 16, 2023."
   logo: "/images/logos/mamiyawikilogo.png"
-  url: "https://mamiyawiki.com/"
+  url: "https://gamingwikinetwork.org/warn/mamiyawiki"
   mainpage: "Main_Page"
   discord: "tNYTQpMd4h"
+  age: 17+
 - member:
   id: "oldworldblueswiki"
   name: "Old World Blues Wiki"
   description: "Old World Blues Wiki is about Old World Blues, a mod for the Paradox grand strategy game Hearts of Iron IV. The mod is set in the world of the Fallout video game series, featuring aspects from both the mainline games, the spin-offs, as well as fan-made expansions on regions and locations, to create a thematic exploration of post-nuclear ethics in a war-torn wasteland."
   logo: "/images/logos/OldWorldBlues.png"
-  url: "https://oldworldblues.wiki.gg/"
+  url: "https://gamingwikinetwork.org/warn/oldworldblueswiki"
   mainpage: "Old_World_Blues_—_HOI4_total_conversion_mod_Wiki"
   discord: "owb"
+  age: 18+
 - member:
   id: "rarewiki"
   name: "Rare Wiki"
   description: "Rare Wiki is a wiki dedicated to covering Rare Ltd. and their franchises (except for Banjo-Kazooie and Conker, as in-depth coverage of these two franchises can be found at Jiggywikki and Conker Wiki respectively)."
   logo: "/images/logos/rare.png"
-  url: "https://rarewiki.com/"
+  url: "https://gamingwikinetwork.org/warn/rarewiki"
   mainpage: "Main_Page"
   discord: "WdP7aXN"
+  age: 17+
 - member:
   id: "raywiki"
   name: "RayWiki"
@@ -135,7 +139,7 @@
   name: "Saints Row Wiki"
   description: "Saints Row Wiki is the largest, most comprehensive player-made information archive about the Saints Row video game series, with Mission Guides, Secrets, Maps and more!"
   logo: "/images/logos/saintsrow.png"
-  url: "https://saintsrow.wiki/"
+  url: "https://gamingwikinetwork.org/warn/saintsrowwiki"
   mainpage: "Saints_Row_Wiki"
   twitter: "saintsrowwiki"
   age: 18+
@@ -177,7 +181,7 @@
   name: "The Coffin of Andy and Leyley Wiki"
   description: "The Coffin of Andy and Leyley Wiki covers the hit game by Kit9Studio since December 31, 2023."
   logo: "/images/logos/tcoaalwiki.jpg"
-  url: "https://coffin.wiki/"
+  url: "https://gamingwikinetwork.org/warn/tcoaalwiki"
   mainpage: "Main_Page"
   discord: "S84qsjQf9e"
   age: 18+
@@ -186,7 +190,7 @@
   name: "Tom Clancy Wiki"
   description: "The Tom Clancy Wiki is a collaborative encyclopedia dedicated to Tom Clancy's franchises. The Tom Clancy franchise is a 40-year old expansive franchise founded by Tom Clancy, telling several unique sagas through books, video games, and films, as well as a TV show."
   logo: "/images/logos/tomclancywiki.png"
-  url: "https://tomclancy.wiki.gg/"
+  url: "https://gamingwikinetwork.org/warn/tomclancywiki"
   mainpage: "Tom_Clancy_Wiki"
   discord: "6JFzHSk8Zj"
   age: 18+

--- a/_layouts/warning.html
+++ b/_layouts/warning.html
@@ -1,0 +1,13 @@
+---
+layout: default
+---
+
+<article class="page">
+
+  <h1>Mature Content Warning</h1>
+  <div class="entry">
+    <p>The wiki you're about to access covers subject matter which may include <b>mature</b> themes.</p>    
+    <a class="button" href="{{ page.link }}"><b>I'm {{ page.age }} or over</b></a> <a onclick="window.history.back()" class="button"><b>I'm under {{ page.age }}</b></a>
+    <br><br>
+  </div>
+</article>

--- a/_posts/2022-12-31-fallout-open.md
+++ b/_posts/2022-12-31-fallout-open.md
@@ -8,4 +8,4 @@ published: true
 We are pleased to announce that our member, the **Independent Fallout Wiki**, has left early access and is open to the public as of today!
 
 ![Fallout Wiki launch explained in detail]({{site.baseurl}}/images/falloutwikilaunch2.png)
-Please check them out at [https://fallout.wiki](https://fallout.wiki).
+Please check them out at [https://fallout.wiki](https://gamingwikinetwork.org/warn/falloutwiki).

--- a/_posts/2023-08-10-mamiyawiki.md
+++ b/_posts/2023-08-10-mamiyawiki.md
@@ -11,4 +11,4 @@ We are pleased to welcome **Mamiya Wiki** as our latest member!
 
 The wiki, in its current form, was founded on April 16, 2023.
 
-Check out the Mamiya Wiki at [https://mamiyawiki.com/](https://mamiyawiki.com/)!
+Check out the Mamiya Wiki at [https://mamiyawiki.com/](https://gamingwikinetwork.org/warn/mamiyawiki)!

--- a/_posts/2024-01-17-tcoaalwiki.md
+++ b/_posts/2024-01-17-tcoaalwiki.md
@@ -9,4 +9,4 @@ We are pleased to welcome **The Coffin of Andy and LeyLey Wiki** as the latest w
 
 **The Coffin of Andy and LeyLey Wiki** is a wiki about the game of the same name by Kit9 Studio. It is a very new wiki, operating only since December 31, 2023.
 
-Check out the wiki at [https://coffin.wiki](https://coffin.wiki)!
+Check out the wiki at [https://coffin.wiki](https://gamingwikinetwork.org/warn/tcoaalwiki)!

--- a/_posts/2024-02-19-oldworldblueswiki.md
+++ b/_posts/2024-02-19-oldworldblueswiki.md
@@ -9,4 +9,4 @@ We are pleased to welcome the **Old World Blues Wiki** as our latest member!
 
 The **Old World Blues Wiki** is a wiki about the mod of the same name for the Paradox grand strategy game Hearts of Iron IV. The mod is set in the world of the Fallout video game series, featuring aspects from both the mainline games, the spin-offs, as well as fan-made expansions on regions and locations, to create a thematic exploration of post-nuclear ethics in a war-torn wasteland.
 
-Check out the wiki at [https://oldworldblues.wiki.gg/](https://oldworldblues.wiki.gg)!
+Check out the wiki at [https://oldworldblues.wiki.gg/](https://gamingwikinetwork.org/warn/oldworldblueswiki)!

--- a/_posts/2024-05-29-tomclancywiki.md
+++ b/_posts/2024-05-29-tomclancywiki.md
@@ -9,4 +9,4 @@ Today we are welcoming **Tom Clancy Wiki** as the GWN's newest member!
 
 The **Tom Clancy Wiki** is a collaborative encyclopedia dedicated to Tom Clancy's franchises. The Tom Clancy franchise is a 40-year old expansive franchise founded by Tom Clancy, telling several unique sagas through books, video games, and films, as well as a TV show.
 
-Check out the wiki at [https://tomclancy.wiki.gg/](https://tomclancy.wiki.gg)!
+Check out the wiki at [https://tomclancy.wiki.gg/](https://gamingwikinetwork.org/warn/tomclancywiki)!

--- a/_posts/2024-10-12-dacw.md
+++ b/_posts/2024-10-12-dacw.md
@@ -9,4 +9,4 @@ Today we are pleased to welcome the **Dune: Awakening Community Wiki** as the ne
 
 The **Dune: Awakening Community Wiki** is the community knowledge base for everything to do with Funcom's latest and boldest MMO Survival game, set on the sands of Arrakis in Frank Herbert's DUNE, in collaboration with from the publishers of Denis Villeneuve's latest movies, Legendary.
 
-Check out the wiki at [https://awakening.wiki](https://awakening.wiki)!
+Check out the wiki at [https://awakening.wiki](https://gamingwikinetwork.org/warn/dacw)!

--- a/_posts/2025-05-13-saintsrowwiki.md
+++ b/_posts/2025-05-13-saintsrowwiki.md
@@ -9,4 +9,4 @@ Please join us in welcoming the **Saints Row Wiki** as our newest member!
 
 **Saints Row Wiki** is the largest, most comprehensive player-made information archive about the Saints Row video game series, with Mission Guides, Secrets, Maps and more!
 
-Check out the wiki at [https://saintsrow.wiki](https://saintsrow.wiki/)!
+Check out the wiki at [https://saintsrow.wiki](https://gamingwikinetwork.org/warn/saintsrowwiki)!

--- a/_posts/2025-05-21-harvesterwiki.md
+++ b/_posts/2025-05-21-harvesterwiki.md
@@ -9,4 +9,4 @@ Please welcome our newest member, the **Harvester Wiki**!
 
 **Harvester Wiki** is the largest, most comprehensive source of Harvester information!
 
-Check out the wiki at [https://harvester.telepedia.net/](https://harvester.telepedia.net/)!
+Check out the wiki at [https://harvester.telepedia.net/](https://gamingwikinetwork.org/warn/harvesterwiki)!

--- a/style.scss
+++ b/style.scss
@@ -124,6 +124,22 @@ img {
   max-width: 100%;
 }
 
+.button {
+  background-color: #ef4e63;
+  border: none;
+  color: white;
+  padding: 15px 32px;
+  text-align: center;
+  text-decoration: none;
+  display: inline-block;
+  font-size: 16px;
+}
+
+a:hover.button, a:active.button {
+  color: white;
+  text-decoration: underline;
+}
+
 // Fixes images in popup boxes from Google Translate
 .gmnoprint img {
   max-width: none;

--- a/warn/conkerwiki.md
+++ b/warn/conkerwiki.md
@@ -1,0 +1,6 @@
+---
+layout: warning
+link: https://conkerwiki.com
+age: 17
+permalink: /warn/conkerwiki
+---

--- a/warn/dacw.md
+++ b/warn/dacw.md
@@ -1,0 +1,6 @@
+---
+layout: warning
+link: https://awakening.wiki
+age: 18
+permalink: /warn/dacw/
+---

--- a/warn/falloutwiki.md
+++ b/warn/falloutwiki.md
@@ -1,0 +1,6 @@
+---
+layout: warning
+link: https://fallout.wiki/
+age: 18
+permalink: /warn/falloutwiki
+---

--- a/warn/finalfantasywiki.md
+++ b/warn/finalfantasywiki.md
@@ -1,0 +1,6 @@
+---
+layout: warning
+link: https://finalfantasywiki.com/
+age: 18
+permalink: /warn/finalfantasywiki
+---

--- a/warn/harvesterwiki.md
+++ b/warn/harvesterwiki.md
@@ -1,0 +1,6 @@
+---
+layout: warning
+link: https://harvester.telepedia.net
+age: 18
+permalink: /warn/harvesterwiki
+---

--- a/warn/mamiyawiki.md
+++ b/warn/mamiyawiki.md
@@ -1,0 +1,6 @@
+---
+layout: warning
+link: https://mamiyawiki.com/
+age: 17
+permalink: /warn/mamiyawiki
+---

--- a/warn/oldworldblueswiki.md
+++ b/warn/oldworldblueswiki.md
@@ -1,0 +1,6 @@
+---
+layout: warning
+link: https://oldworldblues.wiki.gg/
+age: 18
+permalink: /warn/oldworldblueswiki
+---

--- a/warn/rarewiki.md
+++ b/warn/rarewiki.md
@@ -1,0 +1,6 @@
+---
+layout: warning
+link: https://rarewiki.com/
+age: 17
+permalink: /warn/rarewiki
+---

--- a/warn/saintsrowwiki.md
+++ b/warn/saintsrowwiki.md
@@ -1,0 +1,6 @@
+---
+layout: warning
+link: https://saintsrow.wiki/
+age: 18
+permalink: /warn/saintsrowwiki
+---

--- a/warn/tcoaalwiki.md
+++ b/warn/tcoaalwiki.md
@@ -1,0 +1,6 @@
+---
+layout: warning
+link: https://coffin.wiki/
+age: 18
+permalink: /warn/tcoaalwiki
+---

--- a/warn/tomclancywiki.md
+++ b/warn/tomclancywiki.md
@@ -1,0 +1,6 @@
+---
+layout: warning
+link: https://tomclancy.wiki.gg/
+age: 18
+permalink: /warn/tomclancywiki
+---


### PR DESCRIPTION
When clicking on a link to a wiki with potentially mature content, users will now be directed to an age gating page for the relevant wiki.
![image](https://github.com/user-attachments/assets/214464e2-39b0-4ae5-9b0a-f023a11a38e4)

We can also link to these age gated links from the GWN footers.